### PR TITLE
Respect HOMEBREW_PREFIX on macOS

### DIFF
--- a/lib/Readline.pm
+++ b/lib/Readline.pm
@@ -699,7 +699,10 @@ class Readline:ver<0.1.5> {
         # set version to v0.0 so we can check if it was found
         $version = v0.0;
         # homebrew directory
-        @library-path = ('/usr/local/opt/readline/lib')
+        @library-path = $*SPEC.join($,
+          (%*ENV<HOMEBREW_PREFIX> || '/usr/local'),
+          'opt/readline/lib'
+        )
     }
     }
 


### PR DESCRIPTION
Fresh installations of Homebrew on macOS are now created in
/opt/homebrew instead of /usr/local/.

Looking for Readline under $HOMEBREW_PREFIX with a fallback to
'/usr/local' if not set allows us to support both recent
installations under /opt as well as older installations.